### PR TITLE
Replace Microsite with Astro

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,6 @@ A curated list of Node.js modules with native ESM support and resources about ES
 
 - [turf](https://github.com/Turfjs/turf) - a modular geospatial engine written in JavaScript 
 - [cashify](https://github.com/xxczaki/cashify) - lightweight currency conversion library, successor of money.js
-- [microsite](https://github.com/natemoo-re/microsite/) - fast, opinionated static site generator powered by Snowpack
+- [astro](https://github.com/withastro/astro) - build faster websites with the island architecture 
 - [transliterate](https://github.com/sindresorhus/transliterate) - convert Unicode characters to Latin characters using transliteration
 - [emittery](https://github.com/sindresorhus/emittery) - simple and modern async event emitter.


### PR DESCRIPTION
[Astro](https://astro.build/) is a static site generator that is the spiritual successor to Microsite. The author of Microsite now works on Astro, Microsite has not had a commit in over a year, and Astro also is focused on partial hydration. Because of this, I think it would be a good idea to replace the Microsite link with a link to Astro.