### PR TITLE
Add wirepig

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ A curated list of Node.js modules with native ESM support and resources about ES
 - [uvu](https://github.com/lukeed/uvu) - an extremely fast and lightweight test runner for Node.js and the browser.
 - [oletus](https://github.com/bearror/oletus) - minimal ECMAScript Module test runner
 - [hanbi](https://github.com/43081j/hanbi) - a small javascript library for stubbing and spying on methods/functions. 
+- [wirepig](https://github.com/griffinmyers/wirepig) - mock HTTP and TCP dependencies with real sockets.
 
 ### CLI
 


### PR DESCRIPTION
Wirepig lets you stand up mock HTTP and TCP servers for your dependencies, all from within your testing process.

That means even in tests your application sends real requests over localhost, but without giving up the nice ergonomics of programmatically controlled mocks.